### PR TITLE
Merging MathNet into SpeckleStructuralClasses.dll

### DIFF
--- a/SpeckleStructural.sln
+++ b/SpeckleStructural.sln
@@ -89,7 +89,6 @@ Global
 		{DCD8CA38-F4F0-4F00-AF11-F03B089DBDFB}.DebugParallels|x64.ActiveCfg = Debug|Any CPU
 		{DCD8CA38-F4F0-4F00-AF11-F03B089DBDFB}.DebugParallels|x64.Build.0 = Debug|Any CPU
 		{DCD8CA38-F4F0-4F00-AF11-F03B089DBDFB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{DCD8CA38-F4F0-4F00-AF11-F03B089DBDFB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{DCD8CA38-F4F0-4F00-AF11-F03B089DBDFB}.Release|x64.ActiveCfg = Release|Any CPU
 		{DCD8CA38-F4F0-4F00-AF11-F03B089DBDFB}.Release|x64.Build.0 = Release|Any CPU
 		{99E1E652-6808-4B7E-8156-596220B85D74}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -101,7 +100,6 @@ Global
 		{99E1E652-6808-4B7E-8156-596220B85D74}.DebugParallels|x64.ActiveCfg = Debug|Any CPU
 		{99E1E652-6808-4B7E-8156-596220B85D74}.DebugParallels|x64.Build.0 = Debug|Any CPU
 		{99E1E652-6808-4B7E-8156-596220B85D74}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{99E1E652-6808-4B7E-8156-596220B85D74}.Release|Any CPU.Build.0 = Release|Any CPU
 		{99E1E652-6808-4B7E-8156-596220B85D74}.Release|x64.ActiveCfg = Release|Any CPU
 		{99E1E652-6808-4B7E-8156-596220B85D74}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/SpeckleStructural/SpeckleStructural.csproj
+++ b/SpeckleStructural/SpeckleStructural.csproj
@@ -69,34 +69,12 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <UsingTask TaskName="ILMerge.MSBuild.Tasks.ILMerge" AssemblyFile="$(SolutionDir)packages\ILMerge.MSBuild.Tasks.1.0.0.3\tools\ILMerge.MSBuild.Tasks.dll" />
   <Target Name="AfterBuild">
-    <ItemGroup>
-      <MergeAsm1 Include="$(OutputPath)SpeckleStructuralClasses.dll" />
-      <MergeAsm1 Include="$(OutputPath)MathNet.Numerics.dll" />
-      <MergeAsm1 Include="$(OutputPath)MathNet.Spatial.dll" />
-    </ItemGroup>
-    <ItemGroup>
-      <MergeAsm2 Include="$(OutputPath)SpeckleStructuralGSA.dll" />
-      <MergeAsm2 Include="$(OutputPath)MathNet.Numerics.dll" />
-      <MergeAsm2 Include="$(OutputPath)MathNet.Spatial.dll" />
-    </ItemGroup>
-    <PropertyGroup>
-      <MergedAssembly1>$(ProjectDir)$(OutDir)SpeckleStructuralClasses.dll</MergedAssembly1>
-    </PropertyGroup>
-    <PropertyGroup>
-      <MergedAssembly2>$(ProjectDir)$(OutDir)SpeckleStructuralGSA.dll</MergedAssembly2>
-    </PropertyGroup>
-    <Message Text="ILMerge @(MergeAsm1) -&gt; $(MergedAssembly1)" Importance="high" />
-    <ILMerge InputAssemblies="@(MergeAsm1)" OutputFile="$(MergedAssembly1)" TargetKind="SameAsPrimaryAssembly" />
-    <Message Text="ILMerge @(MergeAsm2) -&gt; $(MergedAssembly2)" Importance="high" />
-    <ILMerge InputAssemblies="@(MergeAsm2)" OutputFile="$(MergedAssembly2)" TargetKind="SameAsPrimaryAssembly" />
-    <Delete Files="$(OutputPath)MathNet.Numerics.dll;$(OutputPath)MathNet.Spatial.dll" />
     <!-- REMOVES CRUFT FROM SQLITE -->
     <RemoveDir Directories="$(TargetDir)x64" />
     <RemoveDir Directories="$(TargetDir)x86" />
     <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\SpeckleStructural*.dll;$(TargetDir)\SpeckleGSAInterfaces.dll" />
+      <BuildFiles Include="$(TargetDir)\*.*" />
     </ItemGroup>
     <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(LocalAppData)\SpeckleKits\$(ProjectName)" />
   </Target>

--- a/SpeckleStructural/SpeckleStructural.csproj
+++ b/SpeckleStructural/SpeckleStructural.csproj
@@ -72,41 +72,35 @@
   <UsingTask TaskName="ILMerge.MSBuild.Tasks.ILMerge" AssemblyFile="$(SolutionDir)packages\ILMerge.MSBuild.Tasks.1.0.0.3\tools\ILMerge.MSBuild.Tasks.dll" />
   
   <Target Name="AfterBuild">
-    <!-- For debug build, there is no merging of assemblies in SpeckleStructuralClasses (to help with intellisense)
-	     so do that merging here, for the purpose of copying the result to the %localappdata% location -->
 	<ItemGroup>
       <MergeAsm1 Include="$(TargetDir)SpeckleStructuralClasses.dll" />
       <MergeAsm1 Include="$(TargetDir)MathNet.Numerics.dll" />
       <MergeAsm1 Include="$(TargetDir)MathNet.Spatial.dll" />
     </ItemGroup>
     <PropertyGroup>
-      <MergedAssembly1>$(ProjectDir)$(OutDir)SpeckleStructuralClasses.dll</MergedAssembly1>
+      <MergedAssembly1>$(TargetDir)SpeckleStructuralClasses.dll</MergedAssembly1>
     </PropertyGroup>
-    <Message Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " Text="ILMerge @(MergeAsm1) -&gt; $(MergedAssembly1)" Importance="high" />
-    <ILMerge Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " InputAssemblies="@(MergeAsm1)" OutputFile="$(MergedAssembly1)" TargetKind="SameAsPrimaryAssembly" />
+    <Message Text="ILMerge @(MergeAsm1) -&gt; $(MergedAssembly1)" Importance="high" />
+    <ILMerge InputAssemblies="@(MergeAsm1)" OutputFile="$(MergedAssembly1)" TargetKind="SameAsPrimaryAssembly" />
 
-    <!-- CopyLocal needs to be set to true for these files for for ilmerge to work - that is the case for both debug and release.
-        The release config of SpeckleStructuralClasses deletes these right after merging assemblies (with ilmerge), 
-		but this is not the case for debug build.
-        So for the debug build, they remain and are copied to SpeckleStructural/bin/debug, so they can be deleted here -->
     <ItemGroup>
       <CopiedDllsToDel Include="$(TargetDir)MathNet.Numerics.*" />
       <CopiedDllsToDel Include="$(TargetDir)MathNet.Spatial.*" />
       <CopiedDllsToDel Include="$(TargetDir)Newtonsoft.Json.*" />
       <CopiedDllsToDel Include="$(TargetDir)websocket-sharp.*" />
       <CopiedDllsToDel Include="$(TargetDir)SpeckleCore*.*" />
+	  <CopiedDllsToDel Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " Include="$(TargetDir)*.config" />
     </ItemGroup>
-    <Delete Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " Files="@(CopiedDllsToDel)" />
+    <Delete Files="@(CopiedDllsToDel)" />
 
     <!-- Debug builds result in more output files - useful for debugging.  For release builds being tested on the local computer,
          it is best if these extra files are deleted.  So for release builds only, delete all files in the %localappfiles% sub-directory for this kit -->
     <ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-      <ReleaseCopiedDllsToDel Include="$(TargetDir)*.config" />
       <!-- remove output of previous debug builds -->
-      <ReleaseCopiedDllsToDel Include="$(LocalAppData)\SpeckleKits\$(ProjectName)\*.*" />
+      <ReleaseDllsToDel Include="$(LocalAppData)\SpeckleKits\$(ProjectName)\*.*" />
     </ItemGroup>
     <Message Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " Text="Removing previous files at $(LocalAppData)\SpeckleKits\$(ProjectName)" Importance="high" />
-    <Delete Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " Files="@(ReleaseCopiedDllsToDel)" />
+    <Delete Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " Files="@(ReleaseDllsToDel)" />
 
     <!-- REMOVES CRUFT FROM SQLITE -->
     <RemoveDir Directories="$(TargetDir)x64" />

--- a/SpeckleStructural/SpeckleStructural.csproj
+++ b/SpeckleStructural/SpeckleStructural.csproj
@@ -24,7 +24,7 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>portable</DebugType>
+    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
@@ -66,14 +66,37 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <UsingTask TaskName="ILMerge.MSBuild.Tasks.ILMerge" AssemblyFile="$(SolutionDir)packages\ILMerge.MSBuild.Tasks.1.0.0.3\tools\ILMerge.MSBuild.Tasks.dll" />
   <Target Name="AfterBuild">
+    <ItemGroup>
+      <MergeAsm1 Include="$(OutputPath)SpeckleStructuralClasses.dll" />
+      <MergeAsm1 Include="$(OutputPath)MathNet.Numerics.dll" />
+      <MergeAsm1 Include="$(OutputPath)MathNet.Spatial.dll" />
+    </ItemGroup>
+    <ItemGroup>
+      <MergeAsm2 Include="$(OutputPath)SpeckleStructuralGSA.dll" />
+      <MergeAsm2 Include="$(OutputPath)MathNet.Numerics.dll" />
+      <MergeAsm2 Include="$(OutputPath)MathNet.Spatial.dll" />
+    </ItemGroup>
+    <PropertyGroup>
+      <MergedAssembly1>$(ProjectDir)$(OutDir)SpeckleStructuralClasses.dll</MergedAssembly1>
+    </PropertyGroup>
+    <PropertyGroup>
+      <MergedAssembly2>$(ProjectDir)$(OutDir)SpeckleStructuralGSA.dll</MergedAssembly2>
+    </PropertyGroup>
+    <Message Text="ILMerge @(MergeAsm1) -&gt; $(MergedAssembly1)" Importance="high" />
+    <ILMerge InputAssemblies="@(MergeAsm1)" OutputFile="$(MergedAssembly1)" TargetKind="SameAsPrimaryAssembly" />
+    <Message Text="ILMerge @(MergeAsm2) -&gt; $(MergedAssembly2)" Importance="high" />
+    <ILMerge InputAssemblies="@(MergeAsm2)" OutputFile="$(MergedAssembly2)" TargetKind="SameAsPrimaryAssembly" />
+    <Delete Files="$(OutputPath)MathNet.Numerics.dll;$(OutputPath)MathNet.Spatial.dll" />
     <!-- REMOVES CRUFT FROM SQLITE -->
     <RemoveDir Directories="$(TargetDir)x64" />
     <RemoveDir Directories="$(TargetDir)x86" />
     <ItemGroup>
-      <BuildFiles Include="$(TargetDir)\*.*" />
+      <BuildFiles Include="$(TargetDir)\SpeckleStructural*.dll;$(TargetDir)\SpeckleGSAInterfaces.dll" />
     </ItemGroup>
     <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(LocalAppData)\SpeckleKits\$(ProjectName)" />
   </Target>

--- a/SpeckleStructural/SpeckleStructural.csproj
+++ b/SpeckleStructural/SpeckleStructural.csproj
@@ -69,19 +69,52 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <UsingTask TaskName="ILMerge.MSBuild.Tasks.ILMerge" AssemblyFile="$(SolutionDir)packages\ILMerge.MSBuild.Tasks.1.0.0.3\tools\ILMerge.MSBuild.Tasks.dll" />
+  
   <Target Name="AfterBuild">
+    <!-- For debug build, there is no merging of assemblies in SpeckleStructuralClasses (to help with intellisense)
+	     so do that merging here, for the purpose of copying the result to the %localappdata% location -->
+	<ItemGroup>
+      <MergeAsm1 Include="$(TargetDir)SpeckleStructuralClasses.dll" />
+      <MergeAsm1 Include="$(TargetDir)MathNet.Numerics.dll" />
+      <MergeAsm1 Include="$(TargetDir)MathNet.Spatial.dll" />
+    </ItemGroup>
+    <PropertyGroup>
+      <MergedAssembly1>$(ProjectDir)$(OutDir)SpeckleStructuralClasses.dll</MergedAssembly1>
+    </PropertyGroup>
+    <Message Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " Text="ILMerge @(MergeAsm1) -&gt; $(MergedAssembly1)" Importance="high" />
+    <ILMerge Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " InputAssemblies="@(MergeAsm1)" OutputFile="$(MergedAssembly1)" TargetKind="SameAsPrimaryAssembly" />
+
+    <!-- CopyLocal needs to be set to true for these files for for ilmerge to work - that is the case for both debug and release.
+        The release config of SpeckleStructuralClasses deletes these right after merging assemblies (with ilmerge), 
+		but this is not the case for debug build.
+        So for the debug build, they remain and are copied to SpeckleStructural/bin/debug, so they can be deleted here -->
+    <ItemGroup>
+      <CopiedDllsToDel Include="$(TargetDir)MathNet.Numerics.*" />
+      <CopiedDllsToDel Include="$(TargetDir)MathNet.Spatial.*" />
+      <CopiedDllsToDel Include="$(TargetDir)Newtonsoft.Json.*" />
+      <CopiedDllsToDel Include="$(TargetDir)websocket-sharp.*" />
+      <CopiedDllsToDel Include="$(TargetDir)SpeckleCore*.*" />
+    </ItemGroup>
+    <Delete Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " Files="@(CopiedDllsToDel)" />
+
+    <!-- Debug builds result in more output files - useful for debugging.  For release builds being tested on the local computer,
+         it is best if these extra files are deleted.  So for release builds only, delete all files in the %localappfiles% sub-directory for this kit -->
+    <ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+      <ReleaseCopiedDllsToDel Include="$(TargetDir)*.config" />
+      <!-- remove output of previous debug builds -->
+      <ReleaseCopiedDllsToDel Include="$(LocalAppData)\SpeckleKits\$(ProjectName)\*.*" />
+    </ItemGroup>
+    <Message Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " Text="Removing previous files at $(LocalAppData)\SpeckleKits\$(ProjectName)" Importance="high" />
+    <Delete Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " Files="@(ReleaseCopiedDllsToDel)" />
+
     <!-- REMOVES CRUFT FROM SQLITE -->
     <RemoveDir Directories="$(TargetDir)x64" />
     <RemoveDir Directories="$(TargetDir)x86" />
-	<ItemGroup>
-      <CopiedDllsToDel Include="$(TargetDir)*.config" />
-	  <!-- remove output of previous debug builds -->
-	  <CopiedDllsToDel Include="$(LocalAppData)\SpeckleKits\$(ProjectName)\*.*" />
-    </ItemGroup>
-    <Delete Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU'" Files="@(CopiedDllsToDel)" />
     <ItemGroup>
       <BuildFiles Include="$(TargetDir)\*.*" />
     </ItemGroup>
+    <Message Text="Copying built files to $(LocalAppData)\SpeckleKits\$(ProjectName)" Importance="high" />
     <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(LocalAppData)\SpeckleKits\$(ProjectName)" />
   </Target>
 </Project>

--- a/SpeckleStructural/SpeckleStructural.csproj
+++ b/SpeckleStructural/SpeckleStructural.csproj
@@ -73,6 +73,12 @@
     <!-- REMOVES CRUFT FROM SQLITE -->
     <RemoveDir Directories="$(TargetDir)x64" />
     <RemoveDir Directories="$(TargetDir)x86" />
+	<ItemGroup>
+      <CopiedDllsToDel Include="$(TargetDir)*.config" />
+	  <!-- remove output of previous debug builds -->
+	  <CopiedDllsToDel Include="$(LocalAppData)\SpeckleKits\$(ProjectName)\*.*" />
+    </ItemGroup>
+    <Delete Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU'" Files="@(CopiedDllsToDel)" />
     <ItemGroup>
       <BuildFiles Include="$(TargetDir)\*.*" />
     </ItemGroup>

--- a/SpeckleStructural/packages.config
+++ b/SpeckleStructural/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="ILMerge.MSBuild.Tasks" version="1.0.0.3" targetFramework="net471" />
+</packages>

--- a/SpeckleStructuralClasses/Extensions/Base.cs
+++ b/SpeckleStructuralClasses/Extensions/Base.cs
@@ -1,8 +1,11 @@
-﻿using SpeckleCoreGeometryClasses;
+﻿using MathNet.Numerics.LinearAlgebra;
+using MathNet.Spatial.Euclidean;
+using MathNet.Spatial.Units;
+using SpeckleCoreGeometryClasses;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Windows.Media.Media3D;
+using System.Web;
 
 namespace SpeckleStructuralClasses
 {
@@ -292,10 +295,11 @@ namespace SpeckleStructuralClasses
     {
       if (angle == 0) return;
 
-      var rotationMatrix = RotationMatrix(new Vector3D(Xdir.Value[0], Xdir.Value[1], Xdir.Value[2]), angle);
+      var unitV = (new Vector3D(Xdir.Value[0], Xdir.Value[1], Xdir.Value[2])).Normalize();
+      var rotationMatrix = RotationMatrix(unitV, angle);
 
-      var Y = Vector3D.Multiply(new Vector3D(Ydir.Value[0], Ydir.Value[1], Ydir.Value[2]), rotationMatrix);
-      var Z = Vector3D.Multiply(new Vector3D(Normal.Value[0], Normal.Value[1], Normal.Value[2]), rotationMatrix);
+      var Y = (new Vector3D(Ydir.Value[0], Ydir.Value[1], Ydir.Value[2])).TransformBy(rotationMatrix);
+      var Z = (new Vector3D(Normal.Value[0], Normal.Value[1], Normal.Value[2])).TransformBy(rotationMatrix);
 
       Ydir = new SpeckleVector(Y.X, Y.Y, Y.Z);
       Normal = new SpeckleVector(Z.X, Z.Y, Z.Z);
@@ -305,10 +309,11 @@ namespace SpeckleStructuralClasses
     {
       if (angle == 0) return;
 
-      var rotationMatrix = RotationMatrix(new Vector3D(Ydir.Value[0], Ydir.Value[1], Ydir.Value[2]), angle);
+      var unitV = (new Vector3D(Ydir.Value[0], Ydir.Value[1], Ydir.Value[2])).Normalize();
+      var rotationMatrix = RotationMatrix(unitV, angle);
 
-      var X = Vector3D.Multiply(new Vector3D(Xdir.Value[0], Xdir.Value[1], Xdir.Value[2]), rotationMatrix);
-      var Z = Vector3D.Multiply(new Vector3D(Normal.Value[0], Normal.Value[1], Normal.Value[2]), rotationMatrix);
+      var X = (new Vector3D(Xdir.Value[0], Xdir.Value[1], Xdir.Value[2])).TransformBy(rotationMatrix);
+      var Z = (new Vector3D(Normal.Value[0], Normal.Value[1], Normal.Value[2])).TransformBy(rotationMatrix);
 
       Xdir = new SpeckleVector(X.X, X.Y, X.Z);
       Normal = new SpeckleVector(Z.X, Z.Y, Z.Z);
@@ -318,17 +323,20 @@ namespace SpeckleStructuralClasses
     {
       if (angle == 0) return;
 
-      var rotationMatrix = RotationMatrix(new Vector3D(Normal.Value[0], Normal.Value[1], Normal.Value[2]), angle);
+      var unitV = (new Vector3D(Normal.Value[0], Normal.Value[1], Normal.Value[2])).Normalize();
+      var rotationMatrix = RotationMatrix(unitV, angle);
 
-      var X = Vector3D.Multiply(new Vector3D(Xdir.Value[0], Xdir.Value[1], Xdir.Value[2]), rotationMatrix);
-      var Y = Vector3D.Multiply(new Vector3D(Ydir.Value[0], Ydir.Value[1], Ydir.Value[2]), rotationMatrix);
+      var X = (new Vector3D(Xdir.Value[0], Xdir.Value[1], Xdir.Value[2])).TransformBy(rotationMatrix);
+      var Y = (new Vector3D(Ydir.Value[0], Ydir.Value[1], Ydir.Value[2])).TransformBy(rotationMatrix);
 
       Xdir = new SpeckleVector(X.X, X.Y, X.Z);
       Ydir = new SpeckleVector(Y.X, Y.Y, Y.Z);
     }
 
-    private static Matrix3D RotationMatrix(Vector3D zUnitVector, double angle)
+    private static Matrix<double> RotationMatrix(UnitVector3D zUnitVector, double angle)
     {
+      return Matrix3D.RotationAroundArbitraryVector(zUnitVector, Angle.FromRadians(angle));
+      /*
       var cos = Math.Cos(angle);
       var sin = Math.Sin(angle);
 
@@ -351,6 +359,7 @@ namespace SpeckleStructuralClasses
 
           0, 0, 0, 1
       );
+      */
     }
   }
 }

--- a/SpeckleStructuralClasses/Extensions/NodesAndElements.cs
+++ b/SpeckleStructuralClasses/Extensions/NodesAndElements.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Windows.Media.Media3D;
+using MathNet.Spatial.Euclidean;
 
 namespace SpeckleStructuralClasses
 {
@@ -579,13 +579,13 @@ namespace SpeckleStructuralClasses
       var p2 = new Point3D(coordinates[tri[2] * 3], coordinates[tri[2] * 3 + 1], coordinates[tri[2] * 3 + 2]);
       var p = new Point3D(coordinates[point * 3], coordinates[point * 3 + 1], coordinates[point * 3 + 2]);
 
-      var u = Point3D.Subtract(p1, p0);
-      var v = Point3D.Subtract(p2, p0);
-      var n = Vector3D.CrossProduct(u, v);
-      var w = Point3D.Subtract(p, p0);
+      var u = p1 - p0;
+      var v = p2 - p0;
+      var n = u.CrossProduct(v);
+      var w = p - p0;
 
-      var gamma = Vector3D.DotProduct(Vector3D.CrossProduct(u, w), n) / (n.Length * n.Length);
-      var beta = Vector3D.DotProduct(Vector3D.CrossProduct(w, v), n) / (n.Length * n.Length);
+      var gamma = u.CrossProduct(w).DotProduct(n) / (n.Length * n.Length);
+      var beta = w.CrossProduct(v).DotProduct(n) / (n.Length * n.Length);
       var alpha = 1 - gamma - beta;
 
       if (alpha >= 0 && beta >= 0 && gamma >= 0 && alpha <= 1 && beta <= 1 && gamma <= 1)
@@ -895,13 +895,13 @@ namespace SpeckleStructuralClasses
       var p2 = new Point3D(coordinates[tri[2] * 3], coordinates[tri[2] * 3 + 1], coordinates[tri[2] * 3 + 2]);
       var p = new Point3D(coordinates[point * 3], coordinates[point * 3 + 1], coordinates[point * 3 + 2]);
 
-      var u = Point3D.Subtract(p1, p0);
-      var v = Point3D.Subtract(p2, p0);
-      var n = Vector3D.CrossProduct(u, v);
-      var w = Point3D.Subtract(p, p0);
+      var u = p1 - p0;
+      var v = p2 - p0;
+      var n = u.CrossProduct(v);
+      var w = p - p0;
 
-      var gamma = Vector3D.DotProduct(Vector3D.CrossProduct(u, w), n) / (n.Length * n.Length);
-      var beta = Vector3D.DotProduct(Vector3D.CrossProduct(w, v), n) / (n.Length * n.Length);
+      var gamma = u.CrossProduct(w).DotProduct(n) / (n.Length * n.Length);
+      var beta = w.CrossProduct(v).DotProduct(n) / (n.Length * n.Length);
       var alpha = 1 - gamma - beta;
 
       if (alpha >= 0 & beta >= 0 & gamma >= 0 & alpha <= 1 & beta <= 1 & gamma <= 1)

--- a/SpeckleStructuralClasses/SpeckleStructuralClasses.csproj
+++ b/SpeckleStructuralClasses/SpeckleStructuralClasses.csproj
@@ -143,27 +143,4 @@
   <Import Project="..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets" Condition="Exists('..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets')" />
   <Import Project="..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets" Condition="Exists('..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets')" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
-  <UsingTask TaskName="ILMerge.MSBuild.Tasks.ILMerge" AssemblyFile="$(SolutionDir)packages\ILMerge.MSBuild.Tasks.1.0.0.3\tools\ILMerge.MSBuild.Tasks.dll" />
-  <Target Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU'" Name="AfterBuild">
-    <ItemGroup>
-      <MergeAsm1 Include="$(OutputPath)SpeckleStructuralClasses.dll" />
-      <MergeAsm1 Include="$(OutputPath)MathNet.Numerics.dll" />
-      <MergeAsm1 Include="$(OutputPath)MathNet.Spatial.dll" />
-    </ItemGroup>
-    <PropertyGroup>
-      <MergedAssembly1>$(ProjectDir)$(OutDir)SpeckleStructuralClasses.dll</MergedAssembly1>
-    </PropertyGroup>
-    <Message Text="ILMerge @(MergeAsm1) -&gt; $(MergedAssembly1)" Importance="high" />
-    <ILMerge InputAssemblies="@(MergeAsm1)" OutputFile="$(MergedAssembly1)" TargetKind="SameAsPrimaryAssembly" />
-    <!-- CopyLocal needs to be set to true for these files for for ilmerge to work, but now that it's done, they can be deleted -->
-    <ItemGroup>
-      <CopiedDllsToDel Include="$(OutputPath)MathNet.Numerics.*" />
-      <CopiedDllsToDel Include="$(OutputPath)MathNet.Spatial.*" />
-      <CopiedDllsToDel Include="$(OutputPath)Newtonsoft.Json.*" />
-      <CopiedDllsToDel Include="$(OutputPath)websocket-sharp.*" />
-      <CopiedDllsToDel Include="$(OutputPath)SpeckleCore*.*" />
-      <CopiedDllsToDel Include="$(OutputPath)*.config" />
-    </ItemGroup>
-    <Delete Files="@(CopiedDllsToDel)" />
-  </Target>
 </Project>

--- a/SpeckleStructuralClasses/SpeckleStructuralClasses.csproj
+++ b/SpeckleStructuralClasses/SpeckleStructuralClasses.csproj
@@ -42,6 +42,12 @@
       <HintPath>..\packages\DeviceId.4.3.0\lib\net40\DeviceId.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="MathNet.Numerics, Version=4.9.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MathNet.Numerics.4.9.1\lib\net461\MathNet.Numerics.dll</HintPath>
+    </Reference>
+    <Reference Include="MathNet.Spatial, Version=0.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MathNet.Spatial.0.6.0\lib\net461\MathNet.Spatial.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
       <Private>False</Private>
@@ -58,7 +64,6 @@
       <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="PresentationCore" />
     <Reference Include="SpeckleCore, Version=1.6.9.0, Culture=neutral, processorArchitecture=AMD64">
       <HintPath>..\packages\SpeckleCore.1.6.9\lib\net45\SpeckleCore.dll</HintPath>
       <Private>False</Private>

--- a/SpeckleStructuralClasses/SpeckleStructuralClasses.csproj
+++ b/SpeckleStructuralClasses/SpeckleStructuralClasses.csproj
@@ -36,11 +36,11 @@
   <ItemGroup>
     <Reference Include="Countly, Version=19.8.0.0, Culture=neutral, PublicKeyToken=30fd2b3d8bfe4882, processorArchitecture=MSIL">
       <HintPath>..\packages\Countly.19.8.0\lib\net40-client\Countly.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="DeviceId, Version=4.3.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DeviceId.4.3.0\lib\net40\DeviceId.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="MathNet.Numerics, Version=4.9.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MathNet.Numerics.4.9.1\lib\net461\MathNet.Numerics.dll</HintPath>
@@ -74,7 +74,7 @@
     </Reference>
     <Reference Include="SQLite-net, Version=1.5.231.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\sqlite-net-pcl.1.5.231\lib\netstandard1.1\SQLite-net.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="SQLitePCLRaw.batteries_green, Version=1.1.11.121, Culture=neutral, PublicKeyToken=a84b7dcfb1391f7f, processorArchitecture=MSIL">
       <HintPath>..\packages\SQLitePCLRaw.bundle_green.1.1.11\lib\net45\SQLitePCLRaw.batteries_green.dll</HintPath>
@@ -82,11 +82,11 @@
     </Reference>
     <Reference Include="SQLitePCLRaw.batteries_v2, Version=1.1.11.121, Culture=neutral, PublicKeyToken=8226ea5df37bcae9, processorArchitecture=MSIL">
       <HintPath>..\packages\SQLitePCLRaw.bundle_green.1.1.11\lib\net45\SQLitePCLRaw.batteries_v2.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="SQLitePCLRaw.core, Version=1.1.11.121, Culture=neutral, PublicKeyToken=1488e028ca7ab535, processorArchitecture=MSIL">
       <HintPath>..\packages\SQLitePCLRaw.core.1.1.11\lib\net45\SQLitePCLRaw.core.dll</HintPath>
-      <Private>True</Private>
+      <Private>False</Private>
     </Reference>
     <Reference Include="SQLitePCLRaw.provider.e_sqlite3, Version=1.1.11.121, Culture=neutral, PublicKeyToken=9c301db686d0bd12, processorArchitecture=MSIL">
       <HintPath>..\packages\SQLitePCLRaw.provider.e_sqlite3.net45.1.1.11\lib\net45\SQLitePCLRaw.provider.e_sqlite3.dll</HintPath>
@@ -143,4 +143,26 @@
   <Import Project="..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets" Condition="Exists('..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets')" />
   <Import Project="..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets" Condition="Exists('..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets')" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <UsingTask TaskName="ILMerge.MSBuild.Tasks.ILMerge" AssemblyFile="$(SolutionDir)packages\ILMerge.MSBuild.Tasks.1.0.0.3\tools\ILMerge.MSBuild.Tasks.dll" />
+  <Target Name="AfterBuild">
+    <ItemGroup>
+      <MergeAsm1 Include="$(OutputPath)SpeckleStructuralClasses.dll" />
+      <MergeAsm1 Include="$(OutputPath)MathNet.Numerics.dll" />
+      <MergeAsm1 Include="$(OutputPath)MathNet.Spatial.dll" />
+    </ItemGroup>
+    <PropertyGroup>
+      <MergedAssembly1>$(ProjectDir)$(OutDir)SpeckleStructuralClasses.dll</MergedAssembly1>
+    </PropertyGroup>
+    <Message Text="ILMerge @(MergeAsm1) -&gt; $(MergedAssembly1)" Importance="high" />
+    <ILMerge InputAssemblies="@(MergeAsm1)" OutputFile="$(MergedAssembly1)" TargetKind="SameAsPrimaryAssembly" />
+    <!-- these files needed to be CopyLocal=true for ilmerge to work, but now that it's done, they can be deleted -->
+    <ItemGroup>
+      <CopiedDllsToDel Include="$(OutputPath)MathNet.Numerics.*" />
+      <CopiedDllsToDel Include="$(OutputPath)MathNet.Spatial.*" />
+      <CopiedDllsToDel Include="$(OutputPath)Newtonsoft.Json.*" />
+      <CopiedDllsToDel Include="$(OutputPath)websocket-sharp.*" />
+      <CopiedDllsToDel Include="$(OutputPath)SpeckleCore*.*" />
+    </ItemGroup>
+    <Delete Files="@(CopiedDllsToDel)" />
+  </Target>
 </Project>

--- a/SpeckleStructuralClasses/SpeckleStructuralClasses.csproj
+++ b/SpeckleStructuralClasses/SpeckleStructuralClasses.csproj
@@ -162,7 +162,8 @@
       <CopiedDllsToDel Include="$(OutputPath)Newtonsoft.Json.*" />
       <CopiedDllsToDel Include="$(OutputPath)websocket-sharp.*" />
       <CopiedDllsToDel Include="$(OutputPath)SpeckleCore*.*" />
+      <CopiedDllsToDel Include="$(OutputPath)*.config" />
     </ItemGroup>
-    <Delete Files="@(CopiedDllsToDel)" />
+    <Delete Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU'" Files="@(CopiedDllsToDel)" />
   </Target>
 </Project>

--- a/SpeckleStructuralClasses/SpeckleStructuralClasses.csproj
+++ b/SpeckleStructuralClasses/SpeckleStructuralClasses.csproj
@@ -144,7 +144,7 @@
   <Import Project="..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets" Condition="Exists('..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets')" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <UsingTask TaskName="ILMerge.MSBuild.Tasks.ILMerge" AssemblyFile="$(SolutionDir)packages\ILMerge.MSBuild.Tasks.1.0.0.3\tools\ILMerge.MSBuild.Tasks.dll" />
-  <Target Name="AfterBuild">
+  <Target Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU'" Name="AfterBuild">
     <ItemGroup>
       <MergeAsm1 Include="$(OutputPath)SpeckleStructuralClasses.dll" />
       <MergeAsm1 Include="$(OutputPath)MathNet.Numerics.dll" />
@@ -155,7 +155,7 @@
     </PropertyGroup>
     <Message Text="ILMerge @(MergeAsm1) -&gt; $(MergedAssembly1)" Importance="high" />
     <ILMerge InputAssemblies="@(MergeAsm1)" OutputFile="$(MergedAssembly1)" TargetKind="SameAsPrimaryAssembly" />
-    <!-- these files needed to be CopyLocal=true for ilmerge to work, but now that it's done, they can be deleted -->
+    <!-- CopyLocal needs to be set to true for these files for for ilmerge to work, but now that it's done, they can be deleted -->
     <ItemGroup>
       <CopiedDllsToDel Include="$(OutputPath)MathNet.Numerics.*" />
       <CopiedDllsToDel Include="$(OutputPath)MathNet.Spatial.*" />
@@ -164,6 +164,6 @@
       <CopiedDllsToDel Include="$(OutputPath)SpeckleCore*.*" />
       <CopiedDllsToDel Include="$(OutputPath)*.config" />
     </ItemGroup>
-    <Delete Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU'" Files="@(CopiedDllsToDel)" />
+    <Delete Files="@(CopiedDllsToDel)" />
   </Target>
 </Project>

--- a/SpeckleStructuralClasses/SpeckleStructuralClasses.csproj
+++ b/SpeckleStructuralClasses/SpeckleStructuralClasses.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>portable</DebugType>
+    <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
@@ -26,7 +26,7 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>portable</DebugType>
+    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
@@ -36,11 +36,11 @@
   <ItemGroup>
     <Reference Include="Countly, Version=19.8.0.0, Culture=neutral, PublicKeyToken=30fd2b3d8bfe4882, processorArchitecture=MSIL">
       <HintPath>..\packages\Countly.19.8.0\lib\net40-client\Countly.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="DeviceId, Version=4.3.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DeviceId.4.3.0\lib\net40\DeviceId.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="MathNet.Numerics, Version=4.9.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MathNet.Numerics.4.9.1\lib\net461\MathNet.Numerics.dll</HintPath>
@@ -62,19 +62,19 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="SpeckleCore, Version=1.6.9.0, Culture=neutral, processorArchitecture=AMD64">
       <HintPath>..\packages\SpeckleCore.1.6.9\lib\net45\SpeckleCore.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="SpeckleCoreGeometryClasses, Version=1.2.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SpeckleCoreGeometry.1.2.8\lib\net461\SpeckleCoreGeometryClasses.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="SQLite-net, Version=1.5.231.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\sqlite-net-pcl.1.5.231\lib\netstandard1.1\SQLite-net.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="SQLitePCLRaw.batteries_green, Version=1.1.11.121, Culture=neutral, PublicKeyToken=a84b7dcfb1391f7f, processorArchitecture=MSIL">
       <HintPath>..\packages\SQLitePCLRaw.bundle_green.1.1.11\lib\net45\SQLitePCLRaw.batteries_green.dll</HintPath>
@@ -82,11 +82,11 @@
     </Reference>
     <Reference Include="SQLitePCLRaw.batteries_v2, Version=1.1.11.121, Culture=neutral, PublicKeyToken=8226ea5df37bcae9, processorArchitecture=MSIL">
       <HintPath>..\packages\SQLitePCLRaw.bundle_green.1.1.11\lib\net45\SQLitePCLRaw.batteries_v2.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="SQLitePCLRaw.core, Version=1.1.11.121, Culture=neutral, PublicKeyToken=1488e028ca7ab535, processorArchitecture=MSIL">
       <HintPath>..\packages\SQLitePCLRaw.core.1.1.11\lib\net45\SQLitePCLRaw.core.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="SQLitePCLRaw.provider.e_sqlite3, Version=1.1.11.121, Culture=neutral, PublicKeyToken=9c301db686d0bd12, processorArchitecture=MSIL">
       <HintPath>..\packages\SQLitePCLRaw.provider.e_sqlite3.net45.1.1.11\lib\net45\SQLitePCLRaw.provider.e_sqlite3.dll</HintPath>
@@ -106,7 +106,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="websocket-sharp, Version=1.0.2.32519, Culture=neutral, PublicKeyToken=5660b08a1845a91e, processorArchitecture=MSIL">
       <HintPath>..\packages\WebSocketSharp-NonPreRelease.1.0.0\lib\net35\websocket-sharp.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/SpeckleStructuralClasses/packages.config
+++ b/SpeckleStructuralClasses/packages.config
@@ -2,6 +2,8 @@
 <packages>
   <package id="Countly" version="19.8.0" targetFramework="net471" />
   <package id="DeviceId" version="4.3.0" targetFramework="net471" />
+  <package id="MathNet.Numerics" version="4.9.1" targetFramework="net471" />
+  <package id="MathNet.Spatial" version="0.6.0" targetFramework="net471" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net471" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net471" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net471" />
@@ -15,5 +17,6 @@
   <package id="SQLitePCLRaw.lib.e_sqlite3.osx" version="1.1.11" targetFramework="net471" />
   <package id="SQLitePCLRaw.lib.e_sqlite3.v110_xp" version="1.1.11" targetFramework="net471" />
   <package id="SQLitePCLRaw.provider.e_sqlite3.net45" version="1.1.11" targetFramework="net471" />
+  <package id="System.Diagnostics.Contracts" version="4.3.0" targetFramework="net471" />
   <package id="WebSocketSharp-NonPreRelease" version="1.0.0" targetFramework="net471" />
 </packages>

--- a/SpeckleStructuralClasses/packages.config
+++ b/SpeckleStructuralClasses/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Countly" version="19.8.0" targetFramework="net471" />
   <package id="DeviceId" version="4.3.0" targetFramework="net471" />
+  <package id="ILMerge.MSBuild.Tasks" version="1.0.0.3" targetFramework="net471" />
   <package id="MathNet.Numerics" version="4.9.1" targetFramework="net471" />
   <package id="MathNet.Spatial" version="0.6.0" targetFramework="net471" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net471" />

--- a/SpeckleStructuralClasses/packages.config
+++ b/SpeckleStructuralClasses/packages.config
@@ -2,7 +2,6 @@
 <packages>
   <package id="Countly" version="19.8.0" targetFramework="net471" />
   <package id="DeviceId" version="4.3.0" targetFramework="net471" />
-  <package id="ILMerge.MSBuild.Tasks" version="1.0.0.3" targetFramework="net471" />
   <package id="MathNet.Numerics" version="4.9.1" targetFramework="net471" />
   <package id="MathNet.Spatial" version="0.6.0" targetFramework="net471" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net471" />

--- a/SpeckleStructuralGSA.Test/SpeckleStructuralGSA.Test.csproj
+++ b/SpeckleStructuralGSA.Test/SpeckleStructuralGSA.Test.csproj
@@ -54,11 +54,11 @@
       <HintPath>..\SpeckleStructuralGSA\Interop.Gsa_10_0.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
-    <Reference Include="MathNet.Numerics, Version=4.7.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MathNet.Numerics.4.7.0\lib\net461\MathNet.Numerics.dll</HintPath>
+    <Reference Include="MathNet.Numerics, Version=4.9.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MathNet.Numerics.4.9.1\lib\net461\MathNet.Numerics.dll</HintPath>
     </Reference>
-    <Reference Include="MathNet.Spatial, Version=0.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MathNet.Spatial.0.5.0\lib\net461\MathNet.Spatial.dll</HintPath>
+    <Reference Include="MathNet.Spatial, Version=0.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MathNet.Spatial.0.6.0\lib\net461\MathNet.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Expression.Interactions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Prism.4.1.0.0\lib\NET40\Microsoft.Expression.Interactions.dll</HintPath>

--- a/SpeckleStructuralGSA.Test/TestData/BlankRefsGwaRefords.json
+++ b/SpeckleStructuralGSA.Test/TestData/BlankRefsGwaRefords.json
@@ -51,11 +51,11 @@
   },
   {
     "ApplicationId": "gh/ce14eb199a860bd454baa4e03480aeb4",
-    "GwaCommand": "SET\tLOAD_GRID_LINE.2:{speckle_app_id:gh/ce14eb199a860bd454baa4e03480aeb4}\t \t2\tPOLYGON\t(-0.137446105800758,0.0215770248228732) (0.0591982432154293,0.0215770248228731)\t4\tGLOBAL\tNO\tX\t1E-05\t1E-05"
+    "GwaCommand": "SET\tLOAD_GRID_LINE.2:{speckle_app_id:gh/ce14eb199a860bd454baa4e03480aeb4}\t \t2\tPOLYGON\t(-0.1374461058,0.0215770248) (0.0591982432,0.0215770248)\t4\tGLOBAL\tNO\tX\t1E-05\t1E-05"
   },
   {
     "ApplicationId": "gh/ce14eb199a860bd454baa4e03480aeb4",
-    "GwaCommand": "SET\tLOAD_GRID_LINE.2:{speckle_app_id:gh/ce14eb199a860bd454baa4e03480aeb4}\t \t2\tPOLYGON\t(-0.137446105800758,0.0215770248228732) (0.0591982432154293,0.0215770248228731)\t4\tGLOBAL\tNO\tY\t2E-05\t2E-05"
+    "GwaCommand": "SET\tLOAD_GRID_LINE.2:{speckle_app_id:gh/ce14eb199a860bd454baa4e03480aeb4}\t \t2\tPOLYGON\t(-0.1374461058,0.0215770248) (0.0591982432,0.0215770248)\t4\tGLOBAL\tNO\tY\t2E-05\t2E-05"
   },
   {
     "ApplicationId": "gh/2820605e9ba104099b09ff511bdc6ad9",

--- a/SpeckleStructuralGSA.Test/Tests/MeshTests.cs
+++ b/SpeckleStructuralGSA.Test/Tests/MeshTests.cs
@@ -31,6 +31,7 @@ namespace SpeckleStructuralGSA.Test
       Initialiser.Cache = gsaCache;
       Initialiser.Interface = gsaInterfacer;
       Initialiser.Settings = new Settings();
+      Initialiser.AppUI = new SpeckleAppUI();
     }
 
     [SetUp]

--- a/SpeckleStructuralGSA.Test/Tests/SenderTests.cs
+++ b/SpeckleStructuralGSA.Test/Tests/SenderTests.cs
@@ -94,6 +94,7 @@ namespace SpeckleStructuralGSA.Test
       var unmatching = new List<Tuple<string, string, List<string>>>();
       var unmatchingLock = new object();
       //Compare each object
+
       Parallel.ForEach(actual.Keys, actualObject =>
       {
         var actualJson = actual[actualObject];
@@ -150,7 +151,8 @@ namespace SpeckleStructuralGSA.Test
             unmatching.Add(new Tuple<string, string, List<string>>(actualObject.ApplicationId, actualJson, new List<string>()));
           }
         }
-      });
+      }
+      );
 
       gsaInterfacer.Close();
 

--- a/SpeckleStructuralGSA.Test/packages.config
+++ b/SpeckleStructuralGSA.Test/packages.config
@@ -6,8 +6,8 @@
   <package id="Countly" version="19.8.0" targetFramework="net471" />
   <package id="DeviceId" version="4.3.0" targetFramework="net471" />
   <package id="geometry3Sharp" version="1.0.324" targetFramework="net471" />
-  <package id="MathNet.Numerics" version="4.7.0" targetFramework="net471" />
-  <package id="MathNet.Spatial" version="0.5.0" targetFramework="net471" />
+  <package id="MathNet.Numerics" version="4.9.1" targetFramework="net471" />
+  <package id="MathNet.Spatial" version="0.6.0" targetFramework="net471" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net471" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net471" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net471" />
@@ -24,6 +24,7 @@
   <package id="SQLitePCLRaw.lib.e_sqlite3.osx" version="1.1.11" targetFramework="net471" />
   <package id="SQLitePCLRaw.lib.e_sqlite3.v110_xp" version="1.1.11" targetFramework="net471" />
   <package id="SQLitePCLRaw.provider.e_sqlite3.net45" version="1.1.11" targetFramework="net471" />
+  <package id="System.Diagnostics.Contracts" version="4.3.0" targetFramework="net471" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net471" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net471" />
   <package id="WebSocketSharp-NonPreRelease" version="1.0.0" targetFramework="net471" />

--- a/SpeckleStructuralGSA/ConversionRoutines/Loads/Structural1DLoad.cs
+++ b/SpeckleStructuralGSA/ConversionRoutines/Loads/Structural1DLoad.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Windows.Media.Media3D;
+using MathNet.Spatial.Euclidean;
 using SpeckleCore;
 using SpeckleGSAInterfaces;
 using SpeckleStructuralClasses;
@@ -293,8 +293,8 @@ namespace SpeckleStructuralGSA
             if (loadDirection.Length > 0)
             {
               var axisX = new Vector3D(elem.Value[5] - elem.Value[0], elem.Value[4] - elem.Value[1], elem.Value[3] - elem.Value[2]);
-              var angle = Vector3D.AngleBetween(loadDirection, axisX);
-              var factor = Math.Sin(angle);
+              var angle = loadDirection.AngleTo(axisX);
+              var factor = Math.Sin(angle.Radians);
               load.Value.Loading.Value[0] *= factor;
               load.Value.Loading.Value[1] *= factor;
               load.Value.Loading.Value[2] *= factor;
@@ -369,8 +369,8 @@ namespace SpeckleStructuralGSA
             if (loadDirection.Length > 0)
             {
               var axisX = new Vector3D(memb.Value[5] - memb.Value[0], memb.Value[4] - memb.Value[1], memb.Value[3] - memb.Value[2]);
-              var angle = Vector3D.AngleBetween(loadDirection, axisX);
-              var factor = Math.Sin(angle);
+              var angle = loadDirection.AngleTo(axisX);
+              var factor = Math.Sin(angle.Radians);
               load.Value.Loading.Value[0] *= factor;
               load.Value.Loading.Value[1] *= factor;
               load.Value.Loading.Value[2] *= factor;

--- a/SpeckleStructuralGSA/ConversionRoutines/Loads/Structural2DLoad.cs
+++ b/SpeckleStructuralGSA/ConversionRoutines/Loads/Structural2DLoad.cs
@@ -233,7 +233,15 @@ namespace SpeckleStructuralGSA
 
           // Transform load to defined axis
           var elem = elements.Where(e => e.Value.ApplicationId == nRef).First();
-          StructuralAxis loadAxis = Helper.Parse2DAxis(elem.Value.Vertices.ToArray(), 0, load.Axis != 0); // Assumes if not global, local
+          StructuralAxis loadAxis = null;
+          try
+          { 
+            loadAxis = Helper.Parse2DAxis(elem.Value.Vertices.ToArray(), 0, load.Axis != 0); // Assumes if not global, local
+          }
+          catch
+          {
+            Initialiser.AppUI.Message("Generating axis from coordinates for element ref for 2D load", nRef);
+          }
           load.Value.Loading = initLoad.Value.Loading;
 
           // Perform projection
@@ -292,7 +300,15 @@ namespace SpeckleStructuralGSA
 
           // Transform load to defined axis
           var memb = members.Where(e => e.Value.ApplicationId == nRef).First();
-          StructuralAxis loadAxis = Helper.Parse2DAxis(memb.Value.Vertices.ToArray(), 0, load.Axis != 0); // Assumes if not global, local
+          StructuralAxis loadAxis = null;
+          try
+          {
+            loadAxis = Helper.Parse2DAxis(memb.Value.Vertices.ToArray(), 0, load.Axis != 0); // Assumes if not global, local
+          }
+          catch
+          {
+            Initialiser.AppUI.Message("Generating axis from coordinates for 2D laod", loadAxis.ApplicationId);
+          }
           load.Value.Loading = initLoad.Value.Loading;
           load.Value.Loading.TransformOntoAxis(loadAxis);
 

--- a/SpeckleStructuralGSA/ConversionRoutines/Loads/Structural2DLoadPanel.cs
+++ b/SpeckleStructuralGSA/ConversionRoutines/Loads/Structural2DLoadPanel.cs
@@ -158,7 +158,15 @@ namespace SpeckleStructuralGSA
         return "";
       }
 
-      var axis = Helper.Parse2DAxis(load.Value.ToArray());
+      StructuralAxis axis = null;
+      try
+      {
+        axis = Helper.Parse2DAxis(load.Value.ToArray());
+      }
+      catch
+      {
+        Initialiser.AppUI.Message("Generating axis from coordinates for 2D load panel", load.ApplicationId);
+      }
 
       // Calculate elevation
       var elevation = (load.Value[0] * axis.Normal.Value[0] +

--- a/SpeckleStructuralGSA/ConversionRoutines/NodesAndElements/Structural1DElement.cs
+++ b/SpeckleStructuralGSA/ConversionRoutines/NodesAndElements/Structural1DElement.cs
@@ -52,19 +52,25 @@ namespace SpeckleStructuralGSA
       var orientationNodeRef = pieces[counter++];
       var rotationAngle = Convert.ToDouble(pieces[counter++]);
 
-      if (orientationNodeRef != "0")
+      try
       {
-        var node = nodes.Where(n => n.GSAId == Convert.ToInt32(orientationNodeRef)).FirstOrDefault();
-        node.ForceSend = true;
-        obj.ZAxis = Helper.Parse1DAxis(obj.Value.ToArray(),
-            rotationAngle, node.Value.Value.ToArray()).Normal as StructuralVectorThree;
-        this.SubGWACommand.Add(node.GWACommand);
-      }
-      else
-      {
-        obj.ZAxis = Helper.Parse1DAxis(obj.Value.ToArray(), rotationAngle).Normal as StructuralVectorThree;
-      }
+        if (orientationNodeRef != "0")
+        {
+          var node = nodes.Where(n => n.GSAId == Convert.ToInt32(orientationNodeRef)).FirstOrDefault();
+          node.ForceSend = true;
 
+          obj.ZAxis = Helper.Parse1DAxis(obj.Value.ToArray(), rotationAngle, node.Value.Value.ToArray()).Normal as StructuralVectorThree;
+          this.SubGWACommand.Add(node.GWACommand);
+        }
+        else
+        {
+          obj.ZAxis = Helper.Parse1DAxis(obj.Value.ToArray(), rotationAngle).Normal as StructuralVectorThree;
+        }
+      }
+      catch
+      {
+        Initialiser.AppUI.Message("Generating axis from coordinates for 1D element", obj.ApplicationId);
+      }
 
       if (pieces[counter++] != "NO_RLS")
       {

--- a/SpeckleStructuralGSA/ConversionRoutines/NodesAndElements/Structural2DElement.cs
+++ b/SpeckleStructuralGSA/ConversionRoutines/NodesAndElements/Structural2DElement.cs
@@ -61,9 +61,17 @@ namespace SpeckleStructuralGSA
       counter++; // Orientation node
 
       var prop = props.Where(p => p.Value.ApplicationId == obj.PropertyRef).FirstOrDefault();
-      obj.Axis = Helper.Parse2DAxis(obj.Vertices.ToArray(),
-          Convert.ToDouble(pieces[counter++]),
-          prop == null ? false : (prop as GSA2DProperty).IsAxisLocal);
+      try
+      {
+        obj.Axis = Helper.Parse2DAxis(obj.Vertices.ToArray(),
+            Convert.ToDouble(pieces[counter++]),
+            prop == null ? false : (prop as GSA2DProperty).IsAxisLocal);
+      }
+      catch
+      {
+        Initialiser.AppUI.Message("Generating axis from coordinates for 2D element", obj.ApplicationId);
+      }
+
       if (prop != null)
         this.SubGWACommand.Add(prop.GWACommand);
 
@@ -181,7 +189,7 @@ namespace SpeckleStructuralGSA
     public List<string> SubGWACommand { get; set; } = new List<string>();
     public dynamic Value { get; set; } = new Structural2DElementMesh();
 
-    public void ParseGWACommand( List<GSANode> nodes, List<GSA2DProperty> props)
+    public void ParseGWACommand(List<GSANode> nodes, List<GSA2DProperty> props)
     {
       if (this.GWACommand == null)
         return;
@@ -250,12 +258,26 @@ namespace SpeckleStructuralGSA
       counter++; // Orientation node
 
       var prop = props.Where(p => p.Value.ApplicationId == obj.PropertyRef).FirstOrDefault();
-      var axis = Helper.Parse2DAxis(coordinates.ToArray(),
-          Convert.ToDouble(pieces[counter++]),
-          prop == null ? false : (prop as GSA2DProperty).IsAxisLocal);
-      obj.Axis = Enumerable.Repeat(axis, numFaces).ToList();
-      if (prop != null)
-        this.SubGWACommand.Add(prop.GWACommand);
+      StructuralAxis axis = null;
+      try
+      {
+        axis = Helper.Parse2DAxis(coordinates.ToArray(),
+            Convert.ToDouble(pieces[counter++]),
+            prop == null ? false : (prop as GSA2DProperty).IsAxisLocal);
+      }
+      catch
+      {
+        Initialiser.AppUI.Message("Generating axis from coordinates for 2D member", obj.ApplicationId);
+      }
+
+      if (axis != null)
+      {
+        obj.Axis = Enumerable.Repeat(axis, numFaces).ToList();
+        if (prop != null)
+        {
+          this.SubGWACommand.Add(prop.GWACommand);
+        }
+      }
 
       // Skip to offsets at second to last
       counter = pieces.Length - 2;

--- a/SpeckleStructuralGSA/ConversionRoutines/NodesAndElements/Structural2DElementMesh.cs
+++ b/SpeckleStructuralGSA/ConversionRoutines/NodesAndElements/Structural2DElementMesh.cs
@@ -76,11 +76,15 @@ namespace SpeckleStructuralGSA
                 foreach (var key in resultExport.Value.Keys)
                 {
                   if (!(obj.Result[loadCase] as Structural2DElementResult).Value.ContainsKey(key))
+                  {
                     (obj.Result[loadCase] as Structural2DElementResult).Value[key] = new Dictionary<string, object>(resultExport.Value[key] as Dictionary<string, object>);
+                  }
                   else
                     foreach (var resultKey in ((obj.Result[loadCase] as Structural2DElementResult).Value[key] as Dictionary<string, object>).Keys)
+                    {
                       (((obj.Result[loadCase] as Structural2DElementResult).Value[key] as Dictionary<string, object>)[resultKey] as List<double>)
                         .AddRange((resultExport.Value[key] as Dictionary<string, object>)[resultKey] as List<double>);
+                    }
                 }
               }
               else

--- a/SpeckleStructuralGSA/Helper.cs
+++ b/SpeckleStructuralGSA/Helper.cs
@@ -1,4 +1,6 @@
 ﻿using MathNet.Numerics.LinearAlgebra;
+using MathNet.Spatial.Euclidean;
+using MathNet.Spatial.Units;
 using SpeckleCore;
 using SpeckleCoreGeometryClasses;
 using SpeckleGSAInterfaces;
@@ -8,7 +10,6 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Text.RegularExpressions;
-using System.Windows.Media.Media3D;
 
 namespace SpeckleStructuralGSA
 {
@@ -75,8 +76,10 @@ namespace SpeckleStructuralGSA
     /// <param name="zUnitVector">Z unit vector</param>
     /// <param name="angle">Angle of rotation in radians</param>
     /// <returns>Rotation matrix</returns>
-    public static Matrix3D RotationMatrix(Vector3D zUnitVector, double angle)
+    public static Matrix<double> RotationMatrix(UnitVector3D zUnitVector, double angle)
     {
+      return Matrix3D.RotationAroundArbitraryVector(zUnitVector, Angle.FromRadians(angle));
+      /*
       var cos = Math.Cos(angle);
       var sin = Math.Sin(angle);
 
@@ -99,6 +102,7 @@ namespace SpeckleStructuralGSA
 
           0, 0, 0, 1
       );
+      */
     }
     #endregion
 
@@ -704,42 +708,37 @@ namespace SpeckleStructuralGSA
     /// <returns>Axis</returns>
     public static StructuralAxis Parse1DAxis(double[] coor, double rotationAngle = 0, double[] orientationNode = null)
     {
-      Vector3D x, y, z;
+      UnitVector3D x, y, z;
 
-      x = new Vector3D(coor[3] - coor[0], coor[4] - coor[1], coor[5] - coor[2]);
-      x.Normalize();
+      x = (new Vector3D(coor[3] - coor[0], coor[4] - coor[1], coor[5] - coor[2])).Normalize();
 
       if (orientationNode == null)
       {
         if (x.X == 0 && x.Y == 0)
         {
           //Column
-          y = new Vector3D(0, 1, 0);
-          z = Vector3D.CrossProduct(x, y);
+          y = (new Vector3D(0, 1, 0)).Normalize();
+          z = x.CrossProduct(y);
         }
         else
         {
           //Non-Vertical
           var Z = new Vector3D(0, 0, 1);
-          y = Vector3D.CrossProduct(Z, x);
-          y.Normalize();
-          z = Vector3D.CrossProduct(x, y);
-          z.Normalize();
+          y = Z.CrossProduct(x).Normalize();
+          z = x.CrossProduct(y);
         }
       }
       else
       {
-        var Yp = new Vector3D(orientationNode[0], orientationNode[1], orientationNode[2]);
-        z = Vector3D.CrossProduct(x, Yp);
-        z.Normalize();
-        y = Vector3D.CrossProduct(z, x);
-        y.Normalize();
+        var Yp = (new Vector3D(orientationNode[0], orientationNode[1], orientationNode[2])).Normalize();
+        z = x.CrossProduct(Yp);
+        y = z.CrossProduct(x);
       }
 
       //Rotation
       var rotMat = Helper.RotationMatrix(x, rotationAngle.ToRadians());
-      y = Vector3D.Multiply(y, rotMat);
-      z = Vector3D.Multiply(z, rotMat);
+      y = y.TransformBy(rotMat).Normalize();
+      z = z.TransformBy(rotMat).Normalize();
 
       return new StructuralAxis(
           new StructuralVectorThree(new double[] { x.X, x.Y, x.Z }),
@@ -845,7 +844,7 @@ namespace SpeckleStructuralGSA
     {
       var axisX = new Vector3D(coor[3] - coor[0], coor[4] - coor[1], coor[5] - coor[2]);
       var axisZ = new Vector3D(zAxis.Value[0], zAxis.Value[1], zAxis.Value[2]);
-      var axisY = Vector3D.CrossProduct(axisZ, axisX);
+      var axisY = axisZ.CrossProduct(axisX);
 
       var axis = new StructuralAxis(
           new StructuralVectorThree(new double[] { axisX.X, axisX.Y, axisX.Z }),
@@ -863,13 +862,15 @@ namespace SpeckleStructuralGSA
     /// <param name="rotationAngle">Angle of rotation from default axis</param>
     /// <param name="isLocalAxis">Is axis calculated from local coordinates?</param>
     /// <returns>Axis</returns>
-    public static StructuralAxis Parse2DAxis(double[] coor, double rotationAngle = 0, bool isLocalAxis = false)
+    public static StructuralAxis Parse2DAxis(double[] fullCoords, double rotationAngle = 0, bool isLocalAxis = false)
     {
-      Vector3D x;
-      Vector3D y;
-      Vector3D z;
+      UnitVector3D x;
+      UnitVector3D y;
+      UnitVector3D z;
 
       var nodes = new List<Vector3D>();
+
+      var coor = fullCoords.Essential();
 
       for (var i = 0; i < coor.Length; i += 3)
         nodes.Add(new Vector3D(coor[i], coor[i + 1], coor[i + 2]));
@@ -878,56 +879,40 @@ namespace SpeckleStructuralGSA
       {
         if (nodes.Count == 3)
         {
-          x = Vector3D.Subtract(nodes[1], nodes[0]);
-          x.Normalize();
-          z = Vector3D.CrossProduct(x, Vector3D.Subtract(nodes[2], nodes[0]));
-          z.Normalize();
-          y = Vector3D.CrossProduct(z, x);
-          y.Normalize();
-        }
-        else if (nodes.Count == 4)
-        {
-          x = Vector3D.Subtract(nodes[2], nodes[0]);
-          x.Normalize();
-          z = Vector3D.CrossProduct(x, Vector3D.Subtract(nodes[3], nodes[1]));
-          z.Normalize();
-          y = Vector3D.CrossProduct(z, x);
-          y.Normalize();
+          x = (nodes[1] - nodes[0]).Normalize();
+          z = x.CrossProduct(nodes[2] - nodes[0]).Normalize();
+          y = z.CrossProduct(x);
         }
         else
         {
           // Default to QUAD method
-          x = Vector3D.Subtract(nodes[2], nodes[0]);
-          x.Normalize();
-          z = Vector3D.CrossProduct(x, Vector3D.Subtract(nodes[3], nodes[1]));
-          z.Normalize();
-          y = Vector3D.CrossProduct(z, x);
-          y.Normalize();
+          x = (nodes[2] - nodes[0]).Normalize();
+          z = x.CrossProduct(nodes[3] - nodes[1]).Normalize();
+          y = z.CrossProduct(x);
         }
       }
       else
       {
-        x = Vector3D.Subtract(nodes[1], nodes[0]);
-        x.Normalize();
-        z = Vector3D.CrossProduct(x, Vector3D.Subtract(nodes[2], nodes[0]));
-        z.Normalize();
+        x = (nodes[1] - nodes[0]).Normalize();
+        z = x.CrossProduct(nodes[2] - nodes[0]).Normalize();
 
-        x = new Vector3D(1, 0, 0);
-        x = Vector3D.Subtract(x, Vector3D.Multiply(Vector3D.DotProduct(x, z), z));
+        if ((x - (x.DotProduct(z) * z)).Length == 0)
+        {
+          x = (new Vector3D(0, z.X > 0 ? -1 : 1, 0)).Normalize();
+        }
+        else
+        {
+          x = (new Vector3D(1, 0, 0)).Normalize();
+          x = (x - (x.DotProduct(z) * z)).Normalize();
+        }
 
-        if (x.Length == 0)
-          x = new Vector3D(0, z.X > 0 ? -1 : 1, 0);
-
-        y = Vector3D.CrossProduct(z, x);
-
-        x.Normalize();
-        y.Normalize();
+        y = z.CrossProduct(x);
       }
 
       //Rotation
       var rotMat = Helper.RotationMatrix(z, rotationAngle * (Math.PI / 180));
-      x = Vector3D.Multiply(x, rotMat);
-      y = Vector3D.Multiply(y, rotMat);
+      x = x.TransformBy(rotMat).Normalize();
+      y = y.TransformBy(rotMat).Normalize();
 
       return new StructuralAxis(
           new StructuralVectorThree(new double[] { x.X, x.Y, x.Z }),
@@ -986,7 +971,7 @@ namespace SpeckleStructuralGSA
           x = new Vector3D(evalAtCoor[0], evalAtCoor[1], 0);
           x.Normalize();
           z = new Vector3D(0, 0, 1);
-          y = Vector3D.CrossProduct(z, x);
+          y = z.CrossProduct(x);
 
           return new StructuralAxis(
               new StructuralVectorThree(new double[] { x.X, x.Y, x.Z }),
@@ -1014,10 +999,10 @@ namespace SpeckleStructuralGSA
 
 
           var Yp = new Vector3D(Convert.ToDouble(pieces[10]), Convert.ToDouble(pieces[11]), Convert.ToDouble(pieces[12]));
-          var Z = Vector3D.CrossProduct(X, Yp);
+          var Z = X.CrossProduct(Yp);
           Z.Normalize();
 
-          var Y = Vector3D.CrossProduct(Z, X);
+          var Y = Z.CrossProduct(X);
 
           var pos = new Vector3D(0, 0, 0);
 
@@ -1042,7 +1027,7 @@ namespace SpeckleStructuralGSA
               x = new Vector3D(pos.X, pos.Y, 0);
               x.Normalize();
               z = Z;
-              y = Vector3D.CrossProduct(Z, x);
+              y = Z.CrossProduct(x);
               y.Normalize();
 
               return new StructuralAxis(
@@ -1053,9 +1038,9 @@ namespace SpeckleStructuralGSA
             case "SPH":
               x = pos;
               x.Normalize();
-              z = Vector3D.CrossProduct(Z, x);
+              z = Z.CrossProduct(x);
               z.Normalize();
-              y = Vector3D.CrossProduct(z, x);
+              y = z.CrossProduct(x);
               z.Normalize();
 
               return new StructuralAxis(
@@ -1100,23 +1085,23 @@ namespace SpeckleStructuralGSA
         // Column
         var Yglobal = new Vector3D(0, 1, 0);
 
-        var angle = Math.Acos(Vector3D.DotProduct(Yglobal, axisY) / (Yglobal.Length * axisY.Length)).ToDegrees();
+        var angle = Math.Acos(Yglobal.DotProduct(axisY) / (Yglobal.Length * axisY.Length)).ToDegrees();
         if (double.IsNaN(angle)) return 0;
 
-        var signVector = Vector3D.CrossProduct(Yglobal, axisY);
-        var sign = Vector3D.DotProduct(signVector, axisX);
+        var signVector = Yglobal.CrossProduct(axisY);
+        var sign = signVector.DotProduct(axisX);
 
         return sign >= 0 ? angle : -angle;
       }
       else
       {
         var Zglobal = new Vector3D(0, 0, 1);
-        var Y0 = Vector3D.CrossProduct(Zglobal, axisX);
-        var angle = Math.Acos(Vector3D.DotProduct(Y0, axisY) / (Y0.Length * axisY.Length)).ToDegrees();
+        var Y0 = Zglobal.CrossProduct(axisX);
+        var angle = Math.Acos(Y0.DotProduct(axisY) / (Y0.Length * axisY.Length)).ToDegrees();
         if (double.IsNaN(angle)) angle = 0;
 
-        var signVector = Vector3D.CrossProduct(Y0, axisY);
-        var sign = Vector3D.DotProduct(signVector, axisX);
+        var signVector = Y0.CrossProduct( axisY);
+        var sign = signVector.DotProduct(axisX);
 
         return sign >= 0 ? angle : 360 - angle;
       }
@@ -1143,13 +1128,13 @@ namespace SpeckleStructuralGSA
         nodes.Add(new Vector3D(coor[i], coor[i + 1], coor[i + 2]));
 
       // Get 0 angle axis in GLOBAL coordinates
-      x0 = Vector3D.Subtract(nodes[1], nodes[0]);
+      x0 = nodes[1] - nodes[0];
       x0.Normalize();
-      z0 = Vector3D.CrossProduct(x0, Vector3D.Subtract(nodes[2], nodes[0]));
+      z0 = x0.CrossProduct(nodes[2] - nodes[0]);
       z0.Normalize();
 
       x0 = new Vector3D(1, 0, 0);
-      x0 = Vector3D.Subtract(x0, Vector3D.Multiply(Vector3D.DotProduct(x0, z0), z0));
+      x0 = x0 - (x0.DotProduct(z0) * z0);
 
       if (x0.Length == 0)
         x0 = new Vector3D(0, z0.X > 0 ? -1 : 1, 0);
@@ -1157,11 +1142,11 @@ namespace SpeckleStructuralGSA
       x0.Normalize();
 
       // Find angle
-      var angle = Math.Acos(Vector3D.DotProduct(x0, axisX) / (x0.Length * axisX.Length)).ToDegrees();
+      var angle = Math.Acos(x0.DotProduct(axisX) / (x0.Length * axisX.Length)).ToDegrees();
       if (double.IsNaN(angle)) return 0;
 
-      var signVector = Vector3D.CrossProduct(x0, axisX);
-      var sign = Vector3D.DotProduct(signVector, axisZ);
+      var signVector = x0.CrossProduct(axisX);
+      var sign = signVector.DotProduct(axisZ);
 
       return sign >= 0 ? angle : -angle;
     }

--- a/SpeckleStructuralGSA/SpeckleStructuralGSA.csproj
+++ b/SpeckleStructuralGSA/SpeckleStructuralGSA.csproj
@@ -49,6 +49,12 @@
       <Aliases>global</Aliases>
       <Private>False</Private>
     </Reference>
+    <Reference Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " Include="MathNet.Numerics, Version=4.9.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MathNet.Numerics.4.9.1\lib\net461\MathNet.Numerics.dll</HintPath>
+    </Reference>
+    <Reference Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " Include="MathNet.Spatial, Version=0.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MathNet.Spatial.0.6.0\lib\net461\MathNet.Spatial.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
       <Private>False</Private>

--- a/SpeckleStructuralGSA/SpeckleStructuralGSA.csproj
+++ b/SpeckleStructuralGSA/SpeckleStructuralGSA.csproj
@@ -91,7 +91,6 @@
     <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="PresentationCore" />
     <Reference Include="SpeckleCore, Version=1.6.9.0, Culture=neutral, processorArchitecture=AMD64">
       <HintPath>..\packages\SpeckleCore.1.6.9\lib\net45\SpeckleCore.dll</HintPath>
       <Private>False</Private>

--- a/SpeckleStructuralGSA/SpeckleStructuralGSA.csproj
+++ b/SpeckleStructuralGSA/SpeckleStructuralGSA.csproj
@@ -49,10 +49,10 @@
       <Aliases>global</Aliases>
       <Private>False</Private>
     </Reference>
-    <Reference Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " Include="MathNet.Numerics, Version=4.9.1.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="MathNet.Numerics, Version=4.9.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MathNet.Numerics.4.9.1\lib\net461\MathNet.Numerics.dll</HintPath>
     </Reference>
-    <Reference Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " Include="MathNet.Spatial, Version=0.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="MathNet.Spatial, Version=0.6.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MathNet.Spatial.0.6.0\lib\net461\MathNet.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/SpeckleStructuralGSA/SpeckleStructuralGSA.csproj
+++ b/SpeckleStructuralGSA/SpeckleStructuralGSA.csproj
@@ -28,7 +28,7 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>portable</DebugType>
+    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/SpeckleStructuralGSA/SpeckleStructuralGSA.csproj
+++ b/SpeckleStructuralGSA/SpeckleStructuralGSA.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -50,22 +49,6 @@
       <Aliases>global</Aliases>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Microsoft.Expression.Interactions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Prism.4.1.0.0\lib\NET40\Microsoft.Expression.Interactions.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.Practices.Prism, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Prism.4.1.0.0\lib\NET40\Microsoft.Practices.Prism.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.Practices.Prism.Interactivity, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Prism.4.1.0.0\lib\NET40\Microsoft.Practices.Prism.Interactivity.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\CommonServiceLocator.1.0\lib\NET35\Microsoft.Practices.ServiceLocation.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
       <Private>False</Private>
@@ -81,9 +64,6 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>
-    </Reference>
-    <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="SpeckleCore, Version=1.6.9.0, Culture=neutral, processorArchitecture=AMD64">
       <HintPath>..\packages\SpeckleCore.1.6.9\lib\net45\SpeckleCore.dll</HintPath>
@@ -124,10 +104,6 @@
     <Reference Include="System.Net" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Windows.Interactivity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Prism.4.1.0.0\lib\NET40\System.Windows.Interactivity.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -208,9 +184,14 @@
     <Error Condition="!Exists('..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets'))" />
     <Error Condition="!Exists('..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
-    <Error Condition="!Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.12.0\build\NUnit.props'))" />
   </Target>
   <Import Project="..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets" Condition="Exists('..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets')" />
   <Import Project="..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets" Condition="Exists('..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets')" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="AfterBuild">
+    <ItemGroup>
+      <CopiedDllsToDel Include="$(OutputPath)*.config" />
+    </ItemGroup>
+    <Delete Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU'" Files="@(CopiedDllsToDel)" />
+  </Target>
 </Project>

--- a/SpeckleStructuralGSA/SpeckleStructuralGSA.csproj
+++ b/SpeckleStructuralGSA/SpeckleStructuralGSA.csproj
@@ -50,12 +50,6 @@
       <Aliases>global</Aliases>
       <Private>False</Private>
     </Reference>
-    <Reference Include="MathNet.Numerics, Version=4.7.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MathNet.Numerics.4.7.0\lib\net461\MathNet.Numerics.dll</HintPath>
-    </Reference>
-    <Reference Include="MathNet.Spatial, Version=0.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MathNet.Spatial.0.5.0\lib\net461\MathNet.Spatial.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Expression.Interactions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Prism.4.1.0.0\lib\NET40\Microsoft.Expression.Interactions.dll</HintPath>
       <Private>False</Private>

--- a/SpeckleStructuralGSA/packages.config
+++ b/SpeckleStructuralGSA/packages.config
@@ -1,16 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommonServiceLocator" version="1.0" targetFramework="net471" />
   <package id="Countly" version="19.8.0" targetFramework="net471" />
   <package id="DeviceId" version="4.3.0" targetFramework="net471" />
-  <package id="MathNet.Numerics" version="4.7.0" targetFramework="net471" />
-  <package id="MathNet.Spatial" version="0.5.0" targetFramework="net471" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net471" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net471" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net471" />
-  <package id="NUnit" version="3.12.0" targetFramework="net471" />
-  <package id="Prism" version="4.1.0.0" targetFramework="net471" />
   <package id="SpeckleCore" version="1.6.9" targetFramework="net471" />
   <package id="SpeckleCoreGeometry" version="1.2.8" targetFramework="net471" />
   <package id="sqlite-net-pcl" version="1.5.231" targetFramework="net45" />

--- a/SpeckleStructuralGSA/packages.config
+++ b/SpeckleStructuralGSA/packages.config
@@ -2,6 +2,8 @@
 <packages>
   <package id="Countly" version="19.8.0" targetFramework="net471" />
   <package id="DeviceId" version="4.3.0" targetFramework="net471" />
+  <package id="MathNet.Numerics" version="4.9.1" targetFramework="net471" />
+  <package id="MathNet.Spatial" version="0.6.0" targetFramework="net471" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net471" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net471" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net471" />
@@ -15,5 +17,6 @@
   <package id="SQLitePCLRaw.lib.e_sqlite3.osx" version="1.1.11" targetFramework="net45" />
   <package id="SQLitePCLRaw.lib.e_sqlite3.v110_xp" version="1.1.11" targetFramework="net45" />
   <package id="SQLitePCLRaw.provider.e_sqlite3.net45" version="1.1.11" targetFramework="net45" />
+  <package id="System.Diagnostics.Contracts" version="4.3.0" targetFramework="net471" />
   <package id="WebSocketSharp-NonPreRelease" version="1.0.0" targetFramework="net471" />
 </packages>

--- a/SpeckleStructuralRevit/SpeckleStructuralRevit.csproj
+++ b/SpeckleStructuralRevit/SpeckleStructuralRevit.csproj
@@ -218,4 +218,10 @@
   <Import Project="..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets" Condition="Exists('..\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.osx.targets')" />
   <Import Project="..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets" Condition="Exists('..\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.1.11\build\net35\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets')" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="AfterBuild">
+    <ItemGroup>
+      <CopiedDllsToDel Include="$(OutputPath)*.config" />
+    </ItemGroup>
+    <Delete Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU'" Files="@(CopiedDllsToDel)" />
+  </Target>
 </Project>

--- a/SpeckleStructuralRevit/SpeckleStructuralRevit.csproj
+++ b/SpeckleStructuralRevit/SpeckleStructuralRevit.csproj
@@ -27,12 +27,13 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>portable</DebugType>
+    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Countly, Version=19.8.0.0, Culture=neutral, PublicKeyToken=30fd2b3d8bfe4882, processorArchitecture=MSIL">


### PR DESCRIPTION
This is to avoid issues with plug-ins using older SpeckleCore versions when they load all assemblies in all kit subdirectories.