### PR TITLE
Merged the MathNet libraries into the conversion library too

### DIFF
--- a/SpeckleStructural/SpeckleStructural.csproj
+++ b/SpeckleStructural/SpeckleStructural.csproj
@@ -72,7 +72,7 @@
   <UsingTask TaskName="ILMerge.MSBuild.Tasks.ILMerge" AssemblyFile="$(SolutionDir)packages\ILMerge.MSBuild.Tasks.1.0.0.3\tools\ILMerge.MSBuild.Tasks.dll" />
   
   <Target Name="AfterBuild">
-	<ItemGroup>
+    <ItemGroup>
       <MergeAsm1 Include="$(TargetDir)SpeckleStructuralClasses.dll" />
       <MergeAsm1 Include="$(TargetDir)MathNet.Numerics.dll" />
       <MergeAsm1 Include="$(TargetDir)MathNet.Spatial.dll" />
@@ -82,14 +82,25 @@
     </PropertyGroup>
     <Message Text="ILMerge @(MergeAsm1) -&gt; $(MergedAssembly1)" Importance="high" />
     <ILMerge InputAssemblies="@(MergeAsm1)" OutputFile="$(MergedAssembly1)" TargetKind="SameAsPrimaryAssembly" />
+    <ItemGroup>
+      <MergeAsm2 Include="$(TargetDir)SpeckleStructuralGSA.dll" />
+      <MergeAsm2 Include="$(TargetDir)MathNet.Numerics.dll" />
+      <MergeAsm2 Include="$(TargetDir)MathNet.Spatial.dll" />
+    </ItemGroup>
+    <PropertyGroup>
+      <MergedAssembly2>$(TargetDir)SpeckleStructuralGSA.dll</MergedAssembly2>
+    </PropertyGroup>
+    <Message Text="ILMerge @(MergeAsm2) -&gt; $(MergedAssembly2)" Importance="high" />
+    <ILMerge InputAssemblies="@(MergeAsm2)" OutputFile="$(MergedAssembly2)" TargetKind="SameAsPrimaryAssembly" />
 
     <ItemGroup>
       <CopiedDllsToDel Include="$(TargetDir)MathNet.Numerics.*" />
       <CopiedDllsToDel Include="$(TargetDir)MathNet.Spatial.*" />
       <CopiedDllsToDel Include="$(TargetDir)Newtonsoft.Json.*" />
+      <CopiedDllsToDel Include="$(TargetDir)SQLite-net.*" />
       <CopiedDllsToDel Include="$(TargetDir)websocket-sharp.*" />
       <CopiedDllsToDel Include="$(TargetDir)SpeckleCore*.*" />
-	  <CopiedDllsToDel Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " Include="$(TargetDir)*.config" />
+      <CopiedDllsToDel Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " Include="$(TargetDir)*.config" />
     </ItemGroup>
     <Delete Files="@(CopiedDllsToDel)" />
 

--- a/SpeckleStructuralGSA/SpeckleStructuralGSA.csproj
+++ b/SpeckleStructuralGSA/SpeckleStructuralGSA.csproj
@@ -85,7 +85,8 @@
     </Reference>
     <Reference Include="SQLite-net, Version=1.5.231.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\sqlite-net-pcl.1.5.231\lib\netstandard1.1\SQLite-net.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="SQLitePCLRaw.batteries_green, Version=1.1.11.121, Culture=neutral, PublicKeyToken=a84b7dcfb1391f7f, processorArchitecture=MSIL">
       <HintPath>..\packages\SQLitePCLRaw.bundle_green.1.1.11\lib\net45\SQLitePCLRaw.batteries_green.dll</HintPath>


### PR DESCRIPTION
This is to avoid the issue when SpeckleGSA searches for ToNative and ToSpeckle methods inside SpeckleStructuralGSA.dll.